### PR TITLE
Version 1.0.0 version bump & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v1.0.0 - 2024-??-?? - ???
+## v1.0.0 - 2025-05-04 - Long overdue 1.0
 
 * Address pending octoDNS 2.x deprecations, require minimum of 1.5.x
 

--- a/octodns_fastly/__init__.py
+++ b/octodns_fastly/__init__.py
@@ -7,7 +7,7 @@ from octodns.record import Record
 from octodns.source.base import BaseSource
 from octodns.zone import SubzoneRecordException, Zone
 
-__version__ = __VERSION__ = '0.0.1'
+__version__ = __VERSION__ = '1.0.0'
 
 
 class FastlyAcmeSource(BaseSource):


### PR DESCRIPTION
## v1.0.0 - 2025-05-04 - Long overdue 1.0

* Address pending octoDNS 2.x deprecations, require minimum of 1.5.x